### PR TITLE
Refine B2B page with premium white editorial design

### DIFF
--- a/app/b2b/B2BContent.tsx
+++ b/app/b2b/B2BContent.tsx
@@ -1,55 +1,58 @@
+import Image from "next/image";
 import Link from "next/link";
-import {
-    ArrowRight,
-    Building2,
-    CalendarCheck,
-    ClipboardCheck,
-    Home,
-    Leaf,
-    ShieldCheck,
-    Sprout,
-    Truck,
-    Utensils,
-} from "lucide-react";
+import { ArrowRight, Building2, Home, Sprout, Truck, Utensils } from "lucide-react";
 
 const partnerSegments = [
     {
+        label: "01 / Kitchens",
         icon: Utensils,
         title: "Restaurants & cloud kitchens",
-        description: "Chef-ready vegetables, fruit, herbs, dairy, pantry essentials, and daily top-ups for busy Colombo kitchens.",
+        description: "Chef-ready vegetables, herbs, fruit, dairy, and pantry essentials planned around prep cycles.",
     },
     {
+        label: "02 / Hospitality",
         icon: Building2,
         title: "Hotels, cafes & offices",
-        description: "Reliable recurring supply for breakfast spreads, staff meals, events, boardrooms, and guest-facing hospitality.",
+        description: "Recurring supply for breakfast spreads, staff meals, boardrooms, and event operations.",
     },
     {
+        label: "03 / Homes",
         icon: Home,
         title: "Premium households",
-        description: "Weekly household grocery plans for families, villas, apartments, and private residences that want consistent freshness.",
+        description: "Weekly household baskets for families, apartments, villas, and private residences.",
+    },
+    {
+        label: "04 / Growers",
+        icon: Sprout,
+        title: "Farmer sourcing network",
+        description: "Cleaner demand planning between growers and buyers to reduce waste and protect quality.",
     },
 ];
 
-const operatingModel = [
+const processCards = [
     {
-        icon: Sprout,
-        title: "Farmer-first sourcing",
-        description: "We work with trusted growers and regional farm networks, helping farmers move better harvests while giving buyers cleaner supply.",
+        number: "01",
+        tag: "Sourcing",
+        title: "Farm & supplier planning",
+        description: "Trusted farms, regional suppliers, and seasonal availability mapped before fulfilment.",
     },
     {
-        icon: ClipboardCheck,
-        title: "Quality-controlled picking",
-        description: "Orders are selected for freshness, size, ripeness, and use case, so kitchens and homes receive produce that fits the requirement.",
+        number: "02",
+        tag: "Selection",
+        title: "Picked for use case",
+        description: "Orders selected by freshness, ripeness, size, shelf-life, and kitchen or household needs.",
     },
     {
-        icon: Truck,
-        title: "Planned delivery rhythm",
-        description: "Daily, weekly, and custom recurring delivery schedules help teams reduce last-minute purchasing and inconsistent stock levels.",
+        number: "03",
+        tag: "Rhythm",
+        title: "Recurring supply cycles",
+        description: "Daily, weekly, or custom plans for kitchens, offices, villas, and premium households.",
     },
     {
-        icon: CalendarCheck,
-        title: "Recurring order support",
-        description: "Set repeat baskets for restaurant prep, office pantry needs, household staples, or seasonal produce requirements.",
+        number: "04",
+        tag: "Support",
+        title: "One supply conversation",
+        description: "Adjustments, special items, recurring baskets, and seasonal sourcing handled simply.",
     },
 ];
 
@@ -57,11 +60,11 @@ const serviceAreas = ["Colombo", "Rajagiriya", "Battaramulla", "Nawala", "Nugego
 
 export default function B2BContent() {
     return (
-        <div className="overflow-hidden bg-[#020303] text-white selection:bg-emerald-300 selection:text-zinc-950">
+        <div className="overflow-hidden bg-[#fbfaf6] text-zinc-950 selection:bg-emerald-300 selection:text-zinc-950">
             <HeroSection />
             <PartnerSegments />
-            <FarmerNetwork />
-            <OperatingModel />
+            <EditorialSection />
+            <SupplySystem />
             <ServiceAreaSection />
             <ConciergeSection />
         </div>
@@ -70,43 +73,40 @@ export default function B2BContent() {
 
 function HeroSection() {
     return (
-        <section className="relative min-h-[82vh] overflow-hidden bg-[#050606] px-4 py-28 sm:px-6 lg:px-8">
-            <div className="pointer-events-none absolute inset-0">
-                <div className="absolute inset-0 bg-[radial-gradient(circle_at_top,rgba(16,185,129,0.14),transparent_34%),linear-gradient(180deg,#0b0f0d_0%,#050606_52%,#020303_100%)]" />
-                <div className="absolute left-1/2 top-0 h-px w-[76%] -translate-x-1/2 bg-gradient-to-r from-transparent via-emerald-300/30 to-transparent" />
-                <div className="absolute right-10 top-24 h-72 w-72 rounded-full bg-emerald-300/[0.045] blur-3xl" />
-                <div className="absolute bottom-10 left-10 h-72 w-72 rounded-full bg-amber-300/[0.035] blur-3xl" />
-            </div>
+        <section className="relative flex min-h-[92vh] items-center justify-center overflow-hidden bg-zinc-950 text-white">
+            <Image
+                src="https://images.unsplash.com/photo-1542838132-92c53300491e?q=80&w=2574&auto=format&fit=crop"
+                alt="Fresh produce supply for restaurants, hotels, households and farmers"
+                fill
+                priority
+                sizes="100vw"
+                className="object-cover"
+            />
+            <div className="absolute inset-0 bg-black/45" />
+            <div className="absolute inset-0 bg-gradient-to-b from-black/65 via-black/30 to-[#fbfaf6]" />
+            <div className="absolute inset-0 bg-[radial-gradient(circle_at_50%_20%,rgba(16,185,129,0.2),transparent_34%)]" />
 
-            <div className="container relative z-10 mx-auto flex min-h-[62vh] flex-col items-center justify-center text-center">
-                <span className="rounded-full border border-amber-300/20 bg-amber-300/10 px-4 py-1.5 text-xs font-bold uppercase tracking-[0.24em] text-amber-300">
+            <div className="container relative z-10 mx-auto max-w-5xl px-4 pt-20 text-center">
+                <span className="inline-flex rounded-full border border-white/30 bg-white/10 px-6 py-3 text-xs font-bold uppercase tracking-[0.28em] text-white/90 backdrop-blur-sm">
                     Fresh Pick Supply Network
                 </span>
-                <h1 className="mt-8 max-w-6xl font-serif text-5xl font-medium leading-[0.95] tracking-tight text-white md:text-7xl lg:text-8xl">
-                    Premium produce supply for <span className="italic text-emerald-300">restaurants, farmers & households</span>
+                <h1 className="mt-8 font-serif text-6xl font-medium leading-[0.88] tracking-tight text-white drop-shadow-2xl md:text-8xl lg:text-9xl">
+                    Produce supply,<br />
+                    <span className="italic text-emerald-100">curated.</span>
                 </h1>
-                <p className="mt-8 max-w-3xl text-lg font-light leading-relaxed text-zinc-300 md:text-xl">
-                    A curated farm-to-door procurement service for restaurants, hotels, cafes, offices, and premium homes across Colombo. Consistent sourcing, planned recurring orders, and freshness you can build menus and weekly routines around.
+                <p className="mx-auto mt-8 max-w-3xl text-lg font-light leading-relaxed text-zinc-100 drop-shadow-md md:text-2xl">
+                    Premium fresh produce procurement for Colombo restaurants, hotels, offices, farmer partnerships, and private households.
                 </p>
-
                 <div className="mt-10 flex flex-col items-center justify-center gap-4 sm:flex-row">
-                    <Link href="#apply" className="group rounded-full bg-emerald-300 px-8 py-4 font-bold text-zinc-950 shadow-[0_16px_45px_rgba(16,185,129,0.18)] transition-all duration-300 hover:-translate-y-0.5 hover:bg-emerald-200">
+                    <Link href="#apply" className="group rounded-full bg-white px-8 py-4 font-bold text-zinc-950 shadow-[0_20px_50px_rgba(255,255,255,0.18)] transition-all duration-300 hover:-translate-y-0.5 hover:bg-emerald-50">
                         <span className="flex items-center gap-2">
                             Request a supply plan
                             <ArrowRight className="h-4 w-4 transition-transform group-hover:translate-x-1" />
                         </span>
                     </Link>
-                    <Link href="/products" className="rounded-full border border-white/15 bg-white/[0.03] px-8 py-4 font-medium text-white backdrop-blur-sm transition-all duration-300 hover:border-emerald-300/40 hover:bg-emerald-300/10 hover:text-emerald-100">
-                        Browse products
+                    <Link href="/products" className="rounded-full border border-white/25 bg-white/5 px-8 py-4 font-medium text-white backdrop-blur-sm transition-all duration-300 hover:bg-white/10">
+                        Explore products
                     </Link>
-                </div>
-
-                <div className="mt-14 grid w-full max-w-4xl grid-cols-1 gap-3 text-left sm:grid-cols-3">
-                    {["Direct farmer sourcing", "Recurring grocery plans", "Restaurant-grade fulfilment"].map((item) => (
-                        <div key={item} className="rounded-2xl border border-white/10 bg-white/[0.035] px-5 py-4 text-sm font-medium text-zinc-300">
-                            <span className="mr-2 text-emerald-300">•</span>{item}
-                        </div>
-                    ))}
                 </div>
             </div>
         </section>
@@ -115,26 +115,21 @@ function HeroSection() {
 
 function PartnerSegments() {
     return (
-        <section className="relative border-y border-white/5 bg-[#050606] py-24">
-            <div className="container mx-auto px-4 sm:px-6 lg:px-8">
-                <div className="mb-14 max-w-3xl">
-                    <span className="mb-5 block text-xs font-bold uppercase tracking-[0.24em] text-emerald-300">Who we serve</span>
-                    <h2 className="font-serif text-4xl font-semibold leading-tight tracking-tight text-white md:text-6xl">
-                        Built for daily operations, not one-off grocery runs.
-                    </h2>
-                    <p className="mt-5 text-lg font-light leading-relaxed text-zinc-400">
-                        Fresh Pick supports businesses and households that need dependable quality, repeatable orders, and a cleaner connection between farmers and buyers.
-                    </p>
-                </div>
-
-                <div className="grid gap-5 md:grid-cols-3">
+        <section className="relative z-20 -mt-24 pb-24">
+            <div className="container mx-auto px-4">
+                <div className="mx-auto grid max-w-[1400px] grid-cols-1 border border-zinc-200 bg-white shadow-[0_30px_80px_rgba(9,14,12,0.12)] md:grid-cols-2 lg:grid-cols-4">
                     {partnerSegments.map((segment) => (
-                        <div key={segment.title} className="group rounded-[1.5rem] border border-white/10 bg-white/[0.035] p-8 shadow-[0_24px_80px_rgba(0,0,0,0.32)] transition-all duration-300 hover:-translate-y-1 hover:border-emerald-300/25 hover:bg-emerald-300/[0.045]">
-                            <div className="mb-8 flex h-12 w-12 items-center justify-center rounded-full border border-emerald-300/15 bg-emerald-300/10 text-emerald-300">
-                                <segment.icon className="h-5 w-5" />
+                        <div key={segment.title} className="group min-h-[250px] border-b border-zinc-200 bg-gradient-to-b from-white to-[#fbfaf6] p-8 transition-all duration-300 hover:bg-white md:border-r lg:border-b-0">
+                            <div className="mb-8 flex items-center justify-between gap-4">
+                                <span className="text-[10px] font-black uppercase tracking-[0.24em] text-emerald-900">{segment.label}</span>
+                                <segment.icon className="h-5 w-5 text-emerald-800/60" />
                             </div>
-                            <h3 className="font-serif text-2xl font-semibold text-white">{segment.title}</h3>
-                            <p className="mt-4 text-sm leading-relaxed text-zinc-400">{segment.description}</p>
+                            <h2 className="font-serif text-3xl font-medium leading-tight tracking-tight text-zinc-950">
+                                {segment.title}
+                            </h2>
+                            <p className="mt-4 text-sm leading-relaxed text-zinc-500">
+                                {segment.description}
+                            </p>
                         </div>
                     ))}
                 </div>
@@ -143,34 +138,48 @@ function PartnerSegments() {
     );
 }
 
-function FarmerNetwork() {
+function EditorialSection() {
     return (
-        <section className="relative bg-[#020303] py-24">
-            <div className="pointer-events-none absolute inset-0 bg-[radial-gradient(circle_at_left,rgba(16,185,129,0.08),transparent_34%)]" />
-            <div className="container relative z-10 mx-auto px-4 sm:px-6 lg:px-8">
-                <div className="grid items-center gap-12 lg:grid-cols-[0.9fr_1.1fr]">
-                    <div className="rounded-[1.5rem] border border-white/10 bg-white/[0.035] p-8 md:p-10">
-                        <div className="mb-6 flex h-14 w-14 items-center justify-center rounded-full border border-emerald-300/15 bg-emerald-300/10 text-emerald-300">
-                            <Leaf className="h-6 w-6" />
-                        </div>
-                        <h2 className="font-serif text-4xl font-semibold leading-tight text-white md:text-5xl">
-                            Better demand for farmers. Better freshness for buyers.
-                        </h2>
-                        <p className="mt-6 text-lg font-light leading-relaxed text-zinc-400">
-                            We position Fresh Pick as the coordination layer between Sri Lankan growers, restaurants, hotels, offices, and households. That means clearer demand, less waste, and more consistent access to quality produce.
-                        </p>
+        <section className="bg-[#fbfaf6] pb-28 pt-8">
+            <div className="container mx-auto grid max-w-7xl items-center gap-16 px-4 lg:grid-cols-[0.95fr_1.05fr]">
+                <div className="relative min-h-[520px] md:min-h-[640px]">
+                    <div className="absolute inset-y-0 left-0 right-16 overflow-hidden bg-zinc-100 shadow-[0_24px_70px_rgba(0,0,0,0.14)]">
+                        <Image
+                            src="https://images.unsplash.com/photo-1597362925123-77861d3fbac7?q=80&w=1200&auto=format&fit=crop"
+                            alt="Fresh harvested vegetables prepared for supply"
+                            fill
+                            sizes="(max-width: 1024px) 100vw, 48vw"
+                            className="object-cover"
+                        />
                     </div>
+                    <div className="absolute bottom-16 right-0 h-[320px] w-[240px] overflow-hidden border-[12px] border-[#fbfaf6] bg-zinc-100 shadow-[0_24px_70px_rgba(0,0,0,0.14)] md:h-[360px] md:w-[270px]">
+                        <Image
+                            src="https://images.unsplash.com/photo-1605000797499-95a51c5269ae?q=80&w=1200&auto=format&fit=crop"
+                            alt="Farmer direct produce sourcing for Fresh Pick"
+                            fill
+                            sizes="270px"
+                            className="object-cover"
+                        />
+                    </div>
+                </div>
 
-                    <div className="grid gap-4 sm:grid-cols-2">
+                <div>
+                    <span className="mb-6 block text-xs font-black uppercase tracking-[0.24em] text-emerald-900">From growers to tables</span>
+                    <h2 className="font-serif text-5xl font-medium leading-[0.96] tracking-tight text-zinc-950 md:text-7xl">
+                        A cleaner supply line for <span className="italic text-emerald-900">better freshness.</span>
+                    </h2>
+                    <p className="mt-8 max-w-2xl text-lg font-light leading-relaxed text-zinc-500">
+                        Fresh Pick becomes the coordination layer between Sri Lankan growers, restaurants, hotels, offices, and homes. We plan demand, select the right harvest, and build repeat delivery rhythms that reduce last-minute buying and inconsistent stock.
+                    </p>
+                    <div className="mt-10 grid gap-5 sm:grid-cols-3">
                         {[
-                            "Seasonal harvest planning",
-                            "Grower and supplier coordination",
-                            "Restaurant prep-focused selection",
-                            "Household recurring basket support",
+                            { value: "Daily", label: "Kitchen top-ups" },
+                            { value: "Weekly", label: "Home plans" },
+                            { value: "Local", label: "Grower network" },
                         ].map((item) => (
-                            <div key={item} className="rounded-2xl border border-white/10 bg-black/30 p-6 text-zinc-300">
-                                <ShieldCheck className="mb-5 h-5 w-5 text-emerald-300" />
-                                <p className="font-medium">{item}</p>
+                            <div key={item.label} className="border-t border-zinc-200 pt-5">
+                                <strong className="block font-serif text-4xl font-medium text-zinc-950">{item.value}</strong>
+                                <span className="mt-2 block text-xs font-medium uppercase tracking-[0.14em] text-zinc-500">{item.label}</span>
                             </div>
                         ))}
                     </div>
@@ -180,25 +189,67 @@ function FarmerNetwork() {
     );
 }
 
-function OperatingModel() {
+function SupplySystem() {
     return (
-        <section className="bg-[#050606] py-24">
-            <div className="container mx-auto px-4 sm:px-6 lg:px-8">
-                <div className="mb-14 max-w-3xl">
-                    <span className="mb-5 block text-xs font-bold uppercase tracking-[0.24em] text-emerald-300">How it works</span>
-                    <h2 className="font-serif text-4xl font-semibold leading-tight tracking-tight text-white md:text-6xl">
-                        A premium supply flow with simple operational rules.
-                    </h2>
+        <section className="border-y border-zinc-200 bg-white py-28">
+            <div className="container mx-auto max-w-7xl px-4">
+                <div className="mb-16 grid items-end gap-10 lg:grid-cols-[1.05fr_0.85fr]">
+                    <div>
+                        <span className="mb-6 block text-xs font-black uppercase tracking-[0.24em] text-emerald-900">The operating model</span>
+                        <h2 className="max-w-4xl text-balance font-serif text-5xl font-medium leading-[0.96] tracking-tight text-zinc-950 md:text-7xl">
+                            Reliable supply without making procurement feel <span className="italic text-emerald-900">complicated.</span>
+                        </h2>
+                    </div>
+                    <p className="max-w-md text-lg font-light leading-relaxed text-zinc-500">
+                        A calmer premium section with white space, refined process cards, and one image-led concierge panel for contrast.
+                    </p>
                 </div>
 
-                <div className="grid gap-px overflow-hidden rounded-[1.5rem] border border-white/10 bg-white/10 md:grid-cols-4">
-                    {operatingModel.map((item) => (
-                        <div key={item.title} className="bg-[#080a09] p-8">
-                            <item.icon className="mb-8 h-6 w-6 text-emerald-300" />
-                            <h3 className="font-serif text-2xl font-semibold text-white">{item.title}</h3>
-                            <p className="mt-4 text-sm leading-relaxed text-zinc-400">{item.description}</p>
+                <div className="grid gap-7 lg:grid-cols-[1fr_390px]">
+                    <div className="grid gap-5 md:grid-cols-2">
+                        {processCards.map((card) => (
+                            <div key={card.number} className="flex min-h-[220px] flex-col justify-between border border-zinc-200 bg-[#fbfaf6] p-8 transition-all duration-300 hover:-translate-y-1 hover:shadow-[0_24px_60px_rgba(0,0,0,0.08)]">
+                                <div className="flex items-center justify-between gap-5">
+                                    <span className="font-serif text-4xl font-medium leading-none text-amber-600">{card.number}</span>
+                                    <span className="rounded-full border border-emerald-900/15 bg-emerald-900/[0.05] px-3 py-2 text-[10px] font-black uppercase tracking-[0.14em] text-emerald-900">
+                                        {card.tag}
+                                    </span>
+                                </div>
+                                <div>
+                                    <h3 className="mt-8 font-serif text-3xl font-medium leading-tight tracking-tight text-zinc-950">
+                                        {card.title}
+                                    </h3>
+                                    <p className="mt-4 text-sm leading-relaxed text-zinc-500">
+                                        {card.description}
+                                    </p>
+                                </div>
+                            </div>
+                        ))}
+                    </div>
+
+                    <aside className="relative min-h-[458px] overflow-hidden bg-zinc-950 p-9 text-white shadow-[0_28px_70px_rgba(0,0,0,0.18)]">
+                        <Image
+                            src="https://images.unsplash.com/photo-1528698827591-e19ccd7bc23d?q=80&w=1200&auto=format&fit=crop"
+                            alt="Fresh Pick concierge supply desk for recurring produce plans"
+                            fill
+                            sizes="(max-width: 1024px) 100vw, 390px"
+                            className="object-cover"
+                        />
+                        <div className="absolute inset-0 bg-gradient-to-b from-black/25 via-black/20 to-black/75" />
+                        <div className="absolute inset-0 bg-[radial-gradient(circle_at_top,rgba(16,185,129,0.22),transparent_35%)]" />
+                        <div className="relative z-10 flex h-full flex-col justify-end">
+                            <span className="mb-5 block text-[10px] font-black uppercase tracking-[0.24em] text-emerald-100">Concierge supply desk</span>
+                            <h3 className="font-serif text-4xl font-medium leading-[0.98] tracking-tight text-white">
+                                A human layer for every recurring plan.
+                            </h3>
+                            <p className="mt-5 text-sm leading-relaxed text-white/75">
+                                Built for restaurants, households, offices, and farmers who need consistency, not random ordering.
+                            </p>
+                            <Link href="#apply" className="mt-7 inline-flex w-fit rounded-full bg-white px-5 py-3 text-sm font-black text-zinc-950 transition-colors hover:bg-emerald-50">
+                                Build your plan
+                            </Link>
                         </div>
-                    ))}
+                    </aside>
                 </div>
             </div>
         </section>
@@ -207,16 +258,16 @@ function OperatingModel() {
 
 function ServiceAreaSection() {
     return (
-        <section className="border-y border-white/5 bg-[#020303] py-20">
-            <div className="container mx-auto px-4 sm:px-6 lg:px-8">
-                <div className="grid gap-10 lg:grid-cols-[0.8fr_1.2fr] lg:items-center">
+        <section className="bg-[#fbfaf6] py-20">
+            <div className="container mx-auto max-w-7xl px-4">
+                <div className="grid items-center gap-10 border-y border-zinc-200 py-12 lg:grid-cols-[0.75fr_1.25fr]">
                     <div>
-                        <span className="mb-5 block text-xs font-bold uppercase tracking-[0.24em] text-emerald-300">Colombo delivery coverage</span>
-                        <h2 className="font-serif text-4xl font-semibold text-white md:text-5xl">Local supply, planned around your area.</h2>
+                        <span className="mb-5 block text-xs font-black uppercase tracking-[0.24em] text-emerald-900">Colombo delivery coverage</span>
+                        <h2 className="font-serif text-4xl font-medium tracking-tight text-zinc-950 md:text-5xl">Local supply, planned around your area.</h2>
                     </div>
                     <div className="flex flex-wrap gap-3">
                         {serviceAreas.map((area) => (
-                            <span key={area} className="rounded-full border border-white/10 bg-white/[0.035] px-4 py-2 text-sm text-zinc-300">
+                            <span key={area} className="rounded-full border border-zinc-200 bg-white px-4 py-2 text-sm text-zinc-600 shadow-sm">
                                 {area}
                             </span>
                         ))}
@@ -229,62 +280,52 @@ function ServiceAreaSection() {
 
 function ConciergeSection() {
     return (
-        <section id="apply" className="relative bg-[#050606] py-24">
-            <div className="container mx-auto px-4 sm:px-6 lg:px-8">
-                <div className="overflow-hidden rounded-[1.5rem] border border-white/10 bg-white/[0.035] shadow-[0_24px_80px_rgba(0,0,0,0.45)]">
-                    <div className="grid lg:grid-cols-2">
-                        <div className="relative min-h-[520px] p-8 md:p-12 lg:p-16">
-                            <div className="pointer-events-none absolute inset-0 bg-[radial-gradient(circle_at_top_left,rgba(16,185,129,0.14),transparent_36%)]" />
-                            <div className="relative z-10 flex h-full flex-col justify-between gap-16">
-                                <div>
-                                    <span className="mb-6 block text-xs font-bold uppercase tracking-[0.28em] text-emerald-300">Partnership request</span>
-                                    <h3 className="font-serif text-5xl font-semibold leading-tight text-white md:text-6xl">Build your supply plan</h3>
-                                    <p className="mt-6 max-w-md text-lg font-light leading-relaxed text-zinc-400">
-                                        Tell us whether you are buying for a restaurant, hotel, office, farm supply partnership, or household plan. We will shape the recurring basket around your needs.
-                                    </p>
-                                </div>
-                                <div className="space-y-6 text-sm text-zinc-400">
-                                    <div className="border-l border-emerald-300/30 pl-5">
-                                        <div className="mb-1 text-[10px] font-bold uppercase tracking-widest text-emerald-300">Direct Email</div>
-                                        <a href="mailto:b2b@freshpick.lk" className="text-lg text-white transition-colors hover:text-emerald-300">b2b@freshpick.lk</a>
-                                    </div>
-                                    <div className="border-l border-emerald-300/30 pl-5">
-                                        <div className="mb-1 text-[10px] font-bold uppercase tracking-widest text-emerald-300">Typical plans</div>
-                                        Daily kitchens • Weekly households • Office pantry supply • Farmer sourcing partnerships
-                                    </div>
-                                </div>
+        <section id="apply" className="bg-[#fbfaf6] pb-28 pt-4">
+            <div className="container mx-auto max-w-7xl px-4">
+                <div className="relative overflow-hidden bg-[#050606] p-8 text-white shadow-[0_30px_90px_rgba(5,6,6,0.2)] md:p-14 lg:p-16">
+                    <div className="pointer-events-none absolute inset-0 bg-[radial-gradient(circle_at_top_left,rgba(16,185,129,0.18),transparent_38%)]" />
+                    <div className="relative z-10 grid items-center gap-12 lg:grid-cols-[1.05fr_0.95fr]">
+                        <div>
+                            <span className="mb-6 block text-xs font-black uppercase tracking-[0.24em] text-emerald-200">Partnership request</span>
+                            <h2 className="font-serif text-5xl font-medium leading-[0.98] tracking-tight text-white md:text-7xl">
+                                Build your weekly supply plan.
+                            </h2>
+                            <p className="mt-6 max-w-xl text-lg font-light leading-relaxed text-white/65">
+                                Tell us whether you are buying for a restaurant, hotel, office, farm partnership, or private home. We shape the basket around your volume, delivery area, and quality expectations.
+                            </p>
+                            <div className="mt-10 flex items-center gap-3 text-sm text-white/55">
+                                <Truck className="h-5 w-5 text-emerald-200" />
+                                Daily kitchens, weekly households, office pantry supply, and farmer sourcing partnerships.
                             </div>
                         </div>
 
-                        <div className="border-t border-white/10 bg-black/30 p-8 md:p-12 lg:border-l lg:border-t-0 lg:p-16">
-                            <form className="space-y-7" action="mailto:b2b@freshpick.lk" method="post" encType="text/plain">
+                        <form className="bg-white p-8 text-zinc-950 md:p-10" action="mailto:b2b@freshpick.lk" method="post" encType="text/plain">
+                            <div className="space-y-2">
+                                <InputLike label="Business or household name" name="name" placeholder="e.g. restaurant, office, villa, household" />
+                                <InputLike label="Contact person" name="contact" placeholder="Full name" />
+                                <InputLike label="Phone number" name="phone" placeholder="+94..." />
                                 <div>
-                                    <label className="mb-3 block text-[10px] font-bold uppercase tracking-[0.2em] text-zinc-500">Business or household name</label>
-                                    <input name="name" type="text" className="w-full border-b border-white/10 bg-transparent py-3 text-white outline-none transition-colors placeholder:text-zinc-700 focus:border-emerald-300/60" placeholder="e.g. restaurant, office, villa, household" />
+                                    <label className="sr-only" htmlFor="requirement">Requirement</label>
+                                    <textarea id="requirement" name="requirement" rows={4} className="w-full resize-none border-b border-zinc-200 bg-transparent py-5 text-sm text-zinc-950 outline-none placeholder:text-zinc-400 focus:border-emerald-700" placeholder="Weekly volume, delivery area, produce categories, or farmer partnership interest" />
                                 </div>
-                                <div className="grid gap-7 md:grid-cols-2">
-                                    <div>
-                                        <label className="mb-3 block text-[10px] font-bold uppercase tracking-[0.2em] text-zinc-500">Contact person</label>
-                                        <input name="contact" type="text" className="w-full border-b border-white/10 bg-transparent py-3 text-white outline-none transition-colors placeholder:text-zinc-700 focus:border-emerald-300/60" placeholder="Full name" />
-                                    </div>
-                                    <div>
-                                        <label className="mb-3 block text-[10px] font-bold uppercase tracking-[0.2em] text-zinc-500">Phone</label>
-                                        <input name="phone" type="tel" className="w-full border-b border-white/10 bg-transparent py-3 text-white outline-none transition-colors placeholder:text-zinc-700 focus:border-emerald-300/60" placeholder="+94..." />
-                                    </div>
-                                </div>
-                                <div>
-                                    <label className="mb-3 block text-[10px] font-bold uppercase tracking-[0.2em] text-zinc-500">Requirement</label>
-                                    <textarea name="requirement" rows={4} className="w-full resize-none border-b border-white/10 bg-transparent py-3 text-white outline-none transition-colors placeholder:text-zinc-700 focus:border-emerald-300/60" placeholder="Tell us your weekly volume, delivery area, produce categories, or farmer partnership interest." />
-                                </div>
-                                <button type="submit" className="group flex h-14 w-full items-center justify-center rounded-full bg-emerald-300 px-8 text-sm font-bold uppercase tracking-[0.18em] text-zinc-950 transition-all duration-300 hover:bg-emerald-200">
-                                    Request review
-                                    <ArrowRight className="ml-2 h-4 w-4 transition-transform group-hover:translate-x-1" />
-                                </button>
-                            </form>
-                        </div>
+                            </div>
+                            <button type="submit" className="mt-8 flex h-14 w-full items-center justify-center rounded-full bg-emerald-400 px-8 text-sm font-black uppercase tracking-[0.18em] text-zinc-950 transition-colors hover:bg-emerald-300">
+                                Request review
+                                <ArrowRight className="ml-2 h-4 w-4" />
+                            </button>
+                        </form>
                     </div>
                 </div>
             </div>
         </section>
+    );
+}
+
+function InputLike({ label, name, placeholder }: { label: string; name: string; placeholder: string }) {
+    return (
+        <div>
+            <label className="sr-only" htmlFor={name}>{label}</label>
+            <input id={name} name={name} type="text" className="w-full border-b border-zinc-200 bg-transparent py-5 text-sm text-zinc-950 outline-none placeholder:text-zinc-400 focus:border-emerald-700" placeholder={placeholder} />
+        </div>
     );
 }


### PR DESCRIPTION
## Summary
- Reworked the B2B page UI to follow the subscription page style more closely.
- Added an image-led editorial hero, floating white partner cards, a white operating model section, a premium concierge image card, service area pills, and a dark final CTA.
- Keeps the B2B content for restaurants, hotels, offices, households, and farmer sourcing while making the page feel more premium and less SaaS/dark-heavy.

## Notes
- This is a follow-up to the merged SEO/GEO/performance PR.
- I could not run the local preview/build from the connector, so please check the deployment preview before merging.